### PR TITLE
feat: add account holder name field to UserModel

### DIFF
--- a/src/interfaces/datas/user.ts
+++ b/src/interfaces/datas/user.ts
@@ -23,6 +23,7 @@ export type PublicUserData = Omit<
     | "agreement"
     | "ownProjectIds"
     | "accountBank"
+    | "accountHolderName"
     | "accountNumber"
 > & {
     projectSummarizes: ShowProject[];

--- a/src/interfaces/models/user.ts
+++ b/src/interfaces/models/user.ts
@@ -33,5 +33,6 @@ export interface UserModel {
     cvUrl: string;
     agreement: boolean;
     accountBank: string;
+    accountHolderName: string;
     accountNumber: string;
 }

--- a/src/interfaces/payload/userPayload.ts
+++ b/src/interfaces/payload/userPayload.ts
@@ -14,4 +14,5 @@ export interface EditUserPayload {
     interestCategories: string[];
     accountBank: string;
     accountNumber: string;
+    accountHolderName: string;
 }

--- a/src/libs/databases/firestore/users/createUser.ts
+++ b/src/libs/databases/firestore/users/createUser.ts
@@ -45,6 +45,7 @@ export async function createUser(userData?: Partial<UserModel>): Promise<void> {
             cvUrl: "",
             agreement: userData?.agreement || false,
             accountBank: "",
+            accountHolderName: "",
             accountNumber: "",
         };
 

--- a/src/libs/databases/firestore/users/updateUser.ts
+++ b/src/libs/databases/firestore/users/updateUser.ts
@@ -34,6 +34,8 @@ export async function updateUser(uid: string, newUserData: Partial<UserModel>): 
                 agreement: newUserData.agreement ?? currentUserData.agreement,
                 accountBank: newUserData.accountBank ?? currentUserData.accountBank,
                 accountNumber: newUserData.accountNumber ?? currentUserData.accountNumber,
+                accountHolderName:
+                    newUserData.accountHolderName ?? currentUserData.accountHolderName,
             };
             transaction.update(userDocRef, updateData);
         });


### PR DESCRIPTION
- Updated UserModel interface to include accountHolderName.
- Adjusted relevant API endpoints and libraries to handle the new field.
- Ensured that user creation and updates accommodate the new account holder name.